### PR TITLE
[BEAM-4012] Block stderr to suppress noisy passing tests

### DIFF
--- a/sdks/python/apache_beam/runners/portability/portable_runner_test.py
+++ b/sdks/python/apache_beam/runners/portability/portable_runner_test.py
@@ -40,6 +40,7 @@ from apache_beam.runners.portability import portable_runner
 from apache_beam.runners.portability.local_job_service import LocalJobServicer
 from apache_beam.testing.util import assert_that
 from apache_beam.testing.util import equal_to
+from apache_beam.testing.test_utils import BlockStderr 
 
 
 class PortableRunnerTest(fn_api_runner_test.FnApiRunnerTest):
@@ -166,17 +167,20 @@ class PortableRunnerTest(fn_api_runner_test.FnApiRunnerTest):
   def test_error_message_includes_stage(self):
     # TODO: figure out a way for runner to parse and raise the
     # underlying exception.
-    with self.assertRaises(Exception):
-      with self.create_pipeline() as p:
-        def raise_error(x):
-          raise RuntimeError('x')
-        # pylint: disable=expression-not-assigned
-        (p
-         | beam.Create(['a', 'b'])
-         | 'StageA' >> beam.Map(lambda x: x)
-         | 'StageB' >> beam.Map(lambda x: x)
-         | 'StageC' >> beam.Map(raise_error)
-         | 'StageD' >> beam.Map(lambda x: x))
+
+     # disable STDERR
+    with BlockStderr() as b:
+      with self.assertRaises(Exception):
+        with self.create_pipeline() as p:
+          def raise_error(x):
+            raise RuntimeError('x')
+          # pylint: disable=expression-not-assigned
+          (p
+          | beam.Create(['a', 'b'])
+          | 'StageA' >> beam.Map(lambda x: x)
+          | 'StageB' >> beam.Map(lambda x: x)
+          | 'StageC' >> beam.Map(raise_error)
+          | 'StageD' >> beam.Map(lambda x: x))
 
   def test_error_traceback_includes_user_code(self):
     # TODO: figure out a way for runner to parse and raise the

--- a/sdks/python/apache_beam/runners/portability/portable_runner_test.py
+++ b/sdks/python/apache_beam/runners/portability/portable_runner_test.py
@@ -38,9 +38,9 @@ from apache_beam.portability.api import beam_job_api_pb2_grpc
 from apache_beam.runners.portability import fn_api_runner_test
 from apache_beam.runners.portability import portable_runner
 from apache_beam.runners.portability.local_job_service import LocalJobServicer
+from apache_beam.testing.test_utils import BlockStderr
 from apache_beam.testing.util import assert_that
 from apache_beam.testing.util import equal_to
-from apache_beam.testing.test_utils import BlockStderr 
 
 
 class PortableRunnerTest(fn_api_runner_test.FnApiRunnerTest):
@@ -169,18 +169,18 @@ class PortableRunnerTest(fn_api_runner_test.FnApiRunnerTest):
     # underlying exception.
 
      # disable STDERR
-    with BlockStderr() as b:
+    with BlockStderr():
       with self.assertRaises(Exception):
         with self.create_pipeline() as p:
           def raise_error(x):
             raise RuntimeError('x')
           # pylint: disable=expression-not-assigned
           (p
-          | beam.Create(['a', 'b'])
-          | 'StageA' >> beam.Map(lambda x: x)
-          | 'StageB' >> beam.Map(lambda x: x)
-          | 'StageC' >> beam.Map(raise_error)
-          | 'StageD' >> beam.Map(lambda x: x))
+           | beam.Create(['a', 'b'])
+           | 'StageA' >> beam.Map(lambda x: x)
+           | 'StageB' >> beam.Map(lambda x: x)
+           | 'StageC' >> beam.Map(raise_error)
+           | 'StageD' >> beam.Map(lambda x: x))
 
   def test_error_traceback_includes_user_code(self):
     # TODO: figure out a way for runner to parse and raise the

--- a/sdks/python/apache_beam/testing/test_utils.py
+++ b/sdks/python/apache_beam/testing/test_utils.py
@@ -29,6 +29,8 @@ import os
 import shutil
 import tempfile
 import time
+import sys
+from cStringIO import StringIO
 from builtins import object
 
 from mock import Mock
@@ -179,3 +181,12 @@ def _cleanup_pubsub(components):
     else:
       logging.debug('Cannot delete topic/subscription. %s does not exist.',
                     c.full_name)
+
+# Use it to disable SDTERR
+class BlockStderr(object):
+  def __enter__(self):
+    old_stdeer = sys.stderr
+    sys.stderr = mystderr = StringIO()
+    
+  def __exit__(self, *args, **kargs): 
+    sys.stderr = sys.__stderr__

--- a/sdks/python/apache_beam/testing/test_utils.py
+++ b/sdks/python/apache_beam/testing/test_utils.py
@@ -27,11 +27,11 @@ import imp
 import logging
 import os
 import shutil
+import sys
 import tempfile
 import time
-import sys
-from cStringIO import StringIO
 from builtins import object
+from io import StringIO
 
 from mock import Mock
 from mock import patch
@@ -182,11 +182,11 @@ def _cleanup_pubsub(components):
       logging.debug('Cannot delete topic/subscription. %s does not exist.',
                     c.full_name)
 
+
 # Use it to disable SDTERR
 class BlockStderr(object):
   def __enter__(self):
-    old_stdeer = sys.stderr
-    sys.stderr = mystderr = StringIO()
-    
-  def __exit__(self, *args, **kargs): 
+    sys.stderr = StringIO()
+
+  def __exit__(self, *args, **kargs):
     sys.stderr = sys.__stderr__


### PR DESCRIPTION
**Block stderr to suppress noisy passing tests**

------------------------
The [original PR](https://github.com/apache/beam/pull/6241) had lint errors. Fixed them.
But, this fix does not seem to work. The tests in fn_api_runner_test.FnApiRunnerTestWithGrpc cause the process to go into a deadlock. Also, all the noisy tests use gRPC.
Related issue in gRPC-sensu/sensu-go#1375
Seems to be caused by gRPC.

The process executing the test went into deadlock.
`sudo strace -p <PID>` for that process:
```futex(0x37bb550, FUTEX_WAIT_BITSET_PRIVATE|FUTEX_CLOCK_REALTIME, 0, NULL, ffffffff```
The tests always go into deadlock in 
`test_assert_that (apache_beam.runners.portability.fn_api_runner_test.FnApiRunnerTestWithGrpc)`

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
**JIRA Issue**: https://issues.apache.org/jira/browse/BEAM-4012
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | ---

See [.test-infra/jenkins/README](../.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
