### PR TITLE
[BEAM-7388] Reify PTransform for Python SDK

### DIFF
--- a/sdks/python/apache_beam/transforms/util.py
+++ b/sdks/python/apache_beam/transforms/util.py
@@ -666,3 +666,66 @@ def WithKeys(pcoll, k):
   if callable(k):
     return pcoll | Map(lambda v: (k(v), v))
   return pcoll | Map(lambda v: (k, v))
+
+
+class Reify(object):
+  """PTransforms for converting between explicit and implicit form of various
+  Beam values."""
+
+  @typehints.with_input_types(T)
+  @typehints.with_output_types(T)
+  class Timestamp(PTransform):
+    """PTransform to wrap a value in a TimestampedValue with it's
+    associated timestamp."""
+
+    @staticmethod
+    def add_timestamp_info(element, timestamp=DoFn.TimestampParam):
+      yield TimestampedValue(element, timestamp)
+
+    def expand(self, pcoll):
+      return pcoll | ParDo(self.add_timestamp_info)
+
+  @typehints.with_input_types(T)
+  @typehints.with_output_types(T)
+  class Window(PTransform):
+    """PTransform to convert an element in a PCollection into a tuple of
+    (element, timestamp, window), wrapped in a TimestampedValue with it's
+    associated timestamp."""
+
+    @staticmethod
+    def add_window_info(element, timestamp=DoFn.TimestampParam,
+                        window=DoFn.WindowParam):
+      yield TimestampedValue((element, timestamp, window), timestamp)
+
+    def expand(self, pcoll):
+      return pcoll | ParDo(self.add_window_info)
+
+  @typehints.with_input_types(typehints.KV[K, V])
+  @typehints.with_output_types(typehints.KV[K, V])
+  class TimestampInValue(PTransform):
+    """PTransform to wrap the Value in a KV pair in a TimestampedValue with
+    the element's associated timestamp."""
+
+    @staticmethod
+    def add_timestamp_info(element, timestamp=DoFn.TimestampParam):
+      key, value = element
+      yield (key, TimestampedValue(value, timestamp))
+
+    def expand(self, pcoll):
+      return pcoll | ParDo(self.add_timestamp_info)
+
+  @typehints.with_input_types(typehints.KV[K, V])
+  @typehints.with_output_types(typehints.KV[K, V])
+  class WindowInValue(PTransform):
+    """PTransform to convert the Value in a KV pair into a tuple of
+    (value, timestamp, window), with the whole element being wrapped inside a
+    TimestampedValue."""
+
+    @staticmethod
+    def add_window_info(element, timestamp=DoFn.TimestampParam,
+                        window=DoFn.WindowParam):
+      key, value = element
+      yield TimestampedValue(key, (value, timestamp, window), timestamp)
+
+    def expand(self, pcoll):
+      return pcoll | ParDo(self.add_window_info)

--- a/sdks/python/apache_beam/transforms/util_test.py
+++ b/sdks/python/apache_beam/transforms/util_test.py
@@ -450,9 +450,9 @@ class ReifyTest(unittest.TestCase):
     l = [GlobalWindows.windowed_value('a', 100),
          GlobalWindows.windowed_value('b', 200),
          GlobalWindows.windowed_value('c', 300)]
-    expected = [TestWindowedValue(('a', 100, GlobalWindow), 100, [GlobalWindow()]),
-                TestWindowedValue(('b', 200, GlobalWindow), 200, [GlobalWindow()]),
-                TestWindowedValue(('c', 300, GlobalWindow), 300, [GlobalWindow()])]
+    expected = [TestWindowedValue(('a', 100, GlobalWindow()), 100, [GlobalWindow()]),
+                TestWindowedValue(('b', 200, GlobalWindow()), 200, [GlobalWindow()]),
+                TestWindowedValue(('c', 300, GlobalWindow()), 300, [GlobalWindow()])]
     with TestPipeline() as p:
       pc = p | beam.Create(l)
       reified_pc = pc | util.Reify.Window()
@@ -475,9 +475,9 @@ class ReifyTest(unittest.TestCase):
     l = [GlobalWindows.windowed_value(('a', 1), 100),
          GlobalWindows.windowed_value(('b', 2), 200),
          GlobalWindows.windowed_value(('c', 3), 300)]
-    expected = [TestWindowedValue(('a', (1, 100, GlobalWindow)), 100, [GlobalWindow()]),
-                TestWindowedValue(('b', (2, 200, GlobalWindow)), 200, [GlobalWindow()]),
-                TestWindowedValue(('c', (3, 300, GlobalWindow)), 300, [GlobalWindow()])]
+    expected = [TestWindowedValue(('a', (1, 100, GlobalWindow())), 100, [GlobalWindow()]),
+                TestWindowedValue(('b', (2, 200, GlobalWindow())), 200, [GlobalWindow()]),
+                TestWindowedValue(('c', (3, 300, GlobalWindow())), 300, [GlobalWindow()])]
     with TestPipeline() as p:
       pc = p | beam.Create(l)
       reified_pc = pc | util.Reify.Window()


### PR DESCRIPTION
**Please** add a meaningful description for your change here
Two tests failing that need to be debugged; Traceback:
```
======================================================================
ERROR: test_window (apache_beam.transforms.util_test.ReifyTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/tanay/Coding/beam-umbrella/beam/sdks/python/apache_beam/transforms/util_test.py", line 441, in test_window
    assert_that(reified_pc, equal_to(expected), reify_windows=True)
  File "/home/tanay/Coding/beam-umbrella/beam/sdks/python/apache_beam/pipeline.py", line 426, in __exit__
    self.run().wait_until_finish()
  File "/home/tanay/Coding/beam-umbrella/beam/sdks/python/apache_beam/testing/test_pipeline.py", line 107, in run
    else test_runner_api))
  File "/home/tanay/Coding/beam-umbrella/beam/sdks/python/apache_beam/pipeline.py", line 406, in run
    self._options).run(False)
  File "/home/tanay/Coding/beam-umbrella/beam/sdks/python/apache_beam/pipeline.py", line 419, in run
    return self.runner.run_pipeline(self, self._options)
  File "/home/tanay/Coding/beam-umbrella/beam/sdks/python/apache_beam/runners/direct/direct_runner.py", line 128, in run_pipeline
    return runner.run_pipeline(pipeline, options)
  File "/home/tanay/Coding/beam-umbrella/beam/sdks/python/apache_beam/runners/portability/fn_api_runner.py", line 277, in run_pipeline
    default_environment=self._default_environment))
  File "/home/tanay/Coding/beam-umbrella/beam/sdks/python/apache_beam/runners/portability/fn_api_runner.py", line 281, in run_via_runner_api
    return self.run_stages(*self.create_stages(pipeline_proto))
  File "/home/tanay/Coding/beam-umbrella/beam/sdks/python/apache_beam/runners/portability/fn_api_runner.py", line 357, in run_stages
    stage_context.safe_coders)
  File "/home/tanay/Coding/beam-umbrella/beam/sdks/python/apache_beam/runners/portability/fn_api_runner.py", line 521, in run_stage
    data_input, data_output)
  File "/home/tanay/Coding/beam-umbrella/beam/sdks/python/apache_beam/runners/portability/fn_api_runner.py", line 1227, in process_bundle
    result_future = self._controller.control_handler.push(process_bundle)
  File "/home/tanay/Coding/beam-umbrella/beam/sdks/python/apache_beam/runners/portability/fn_api_runner.py", line 842, in push
    response = self.worker.do_instruction(request)
  File "/home/tanay/Coding/beam-umbrella/beam/sdks/python/apache_beam/runners/worker/sdk_worker.py", line 342, in do_instruction
    request.instruction_id)
  File "/home/tanay/Coding/beam-umbrella/beam/sdks/python/apache_beam/runners/worker/sdk_worker.py", line 368, in process_bundle
    bundle_processor.process_bundle(instruction_id))
  File "/home/tanay/Coding/beam-umbrella/beam/sdks/python/apache_beam/runners/worker/bundle_processor.py", line 589, in process_bundle
    ].process_encoded(data.data)
  File "/home/tanay/Coding/beam-umbrella/beam/sdks/python/apache_beam/runners/worker/bundle_processor.py", line 143, in process_encoded
    self.output(decoded_value)
  File "/home/tanay/Coding/beam-umbrella/beam/sdks/python/apache_beam/runners/worker/operations.py", line 256, in output
    cython.cast(Receiver, self.receivers[output_index]).receive(windowed_value)
  File "/home/tanay/Coding/beam-umbrella/beam/sdks/python/apache_beam/runners/worker/operations.py", line 143, in receive
    self.consumer.process(windowed_value)
  File "/home/tanay/Coding/beam-umbrella/beam/sdks/python/apache_beam/runners/worker/operations.py", line 594, in process
    delayed_application = self.dofn_receiver.receive(o)
  File "/home/tanay/Coding/beam-umbrella/beam/sdks/python/apache_beam/runners/common.py", line 759, in receive
    self.process(windowed_value)
  File "/home/tanay/Coding/beam-umbrella/beam/sdks/python/apache_beam/runners/common.py", line 765, in process
    self._reraise_augmented(exn)
  File "/home/tanay/Coding/beam-umbrella/beam/sdks/python/apache_beam/runners/common.py", line 763, in process
    return self.do_fn_invoker.invoke_process(windowed_value)
  File "/home/tanay/Coding/beam-umbrella/beam/sdks/python/apache_beam/runners/common.py", line 576, in invoke_process
    windowed_value, additional_args, additional_kwargs, output_processor)
  File "/home/tanay/Coding/beam-umbrella/beam/sdks/python/apache_beam/runners/common.py", line 647, in _invoke_process_per_window
    windowed_value, self.process_method(*args_for_process))
  File "/home/tanay/Coding/beam-umbrella/beam/sdks/python/apache_beam/runners/common.py", line 902, in process_outputs
    self.main_receivers.receive(windowed_value)
  File "/home/tanay/Coding/beam-umbrella/beam/sdks/python/apache_beam/runners/worker/operations.py", line 143, in receive
    self.consumer.process(windowed_value)
  File "/home/tanay/Coding/beam-umbrella/beam/sdks/python/apache_beam/runners/worker/operations.py", line 594, in process
    delayed_application = self.dofn_receiver.receive(o)
  File "/home/tanay/Coding/beam-umbrella/beam/sdks/python/apache_beam/runners/common.py", line 759, in receive
    self.process(windowed_value)
  File "/home/tanay/Coding/beam-umbrella/beam/sdks/python/apache_beam/runners/common.py", line 765, in process
    self._reraise_augmented(exn)
  File "/home/tanay/Coding/beam-umbrella/beam/sdks/python/apache_beam/runners/common.py", line 763, in process
    return self.do_fn_invoker.invoke_process(windowed_value)
  File "/home/tanay/Coding/beam-umbrella/beam/sdks/python/apache_beam/runners/common.py", line 435, in invoke_process
    windowed_value, self.process_method(windowed_value.value))
  File "/home/tanay/Coding/beam-umbrella/beam/sdks/python/apache_beam/runners/common.py", line 902, in process_outputs
    self.main_receivers.receive(windowed_value)
  File "/home/tanay/Coding/beam-umbrella/beam/sdks/python/apache_beam/runners/worker/operations.py", line 143, in receive
    self.consumer.process(windowed_value)
  File "/home/tanay/Coding/beam-umbrella/beam/sdks/python/apache_beam/runners/worker/operations.py", line 594, in process
    delayed_application = self.dofn_receiver.receive(o)
  File "/home/tanay/Coding/beam-umbrella/beam/sdks/python/apache_beam/runners/common.py", line 759, in receive
    self.process(windowed_value)
  File "/home/tanay/Coding/beam-umbrella/beam/sdks/python/apache_beam/runners/common.py", line 765, in process
    self._reraise_augmented(exn)
  File "/home/tanay/Coding/beam-umbrella/beam/sdks/python/apache_beam/runners/common.py", line 832, in _reraise_augmented
    raise_with_traceback(new_exn)
  File "/home/tanay/Coding/beam-umbrella/beam/sdks/python/apache_beam/runners/common.py", line 763, in process
    return self.do_fn_invoker.invoke_process(windowed_value)
  File "/home/tanay/Coding/beam-umbrella/beam/sdks/python/apache_beam/runners/common.py", line 435, in invoke_process
    windowed_value, self.process_method(windowed_value.value))
  File "/home/tanay/Coding/beam-umbrella/beam/sdks/python/apache_beam/transforms/core.py", line 1292, in <lambda>
    wrapper = lambda x: [fn(x)]
  File "/home/tanay/Coding/beam-umbrella/beam/sdks/python/apache_beam/testing/util.py", line 128, in _equal
    'Failed assert: %r == %r' % (sorted_expected, sorted_actual))
BeamAssertException: Failed assert: [TestWindowedValue(value=('a', 100, <class 'apache_beam.transforms.window.GlobalWindow'>), timestamp=100, windows=[GlobalWindow]), TestWindowedValue(value=('b', 200, <class 'apache_beam.transforms.window.GlobalWindow'>), timestamp=200, windows=[GlobalWindow]), TestWindowedValue(value=('c', 300, <class 'apache_beam.transforms.window.GlobalWindow'>), timestamp=300, windows=[GlobalWindow])] == [TestWindowedValue(value=('a', Timestamp(100), GlobalWindow), timestamp=Timestamp(100), windows=[GlobalWindow]), TestWindowedValue(value=('b', Timestamp(200), GlobalWindow), timestamp=Timestamp(200), windows=[GlobalWindow]), TestWindowedValue(value=('c', Timestamp(300), GlobalWindow), timestamp=Timestamp(300), windows=[GlobalWindow])] [while running 'assert_that/Match']

```
------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python3_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) <br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
